### PR TITLE
Add workflow to build on pushes and internal PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
       - name: Build
-        run: dotnet build "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" -c Release
+        run: dotnet msbuild "Scripts/nightly.proj" -t:Rebuild -v:m -p:ContinuousIntegrationBuild=true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,39 @@
+﻿name: Build
+
+on:
+    pull_request:
+        branches:
+            - '**'
+        types:
+            - opened
+            - synchronize
+            - reopened
+    push:
+        branches:
+            - '**'
+        paths-ignore:
+            - '.git*'
+            - '.vscode'
+
+jobs:
+    build:
+        runs-on: windows-2022
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+              with:
+                  ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+
+            - name: Setup MSBuild
+              uses: microsoft/setup-msbuild@v1
+
+            - name: Setup NuGet
+              uses: NuGet/setup-nuget@v1.0.6
+
+            - name: Restore Packages
+              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+
+            - name: Build Solution
+              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" /p:platform="Any CPU" /p:configuration="Release"
+# End of workflow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,14 +36,30 @@ jobs:
           dotnet-version: 10.0.x
           dotnet-quality: preview
 
+      # global.json dynamisch erzeugen
+      - name: Force .NET 10 SDK via global.json
+        run: |
+          $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]
+          Write-Output "Using SDK $sdkVersion"
+          @"
+          {
+            "sdk": {
+              "version": "$sdkVersion",
+              "rollForward": "latestFeature"
+            }
+          }
+          "@ | Out-File -Encoding utf8 global.json
+
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: x64
 
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.2.0
 
-      - name: Restore Packages
-        run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
+      - name: Restore
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
-      - name: Build Solution
+      - name: Build
         run: msbuild "Scripts/nightly.proj" /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,14 +38,12 @@ jobs:
 
       - name: Setup MSBuild
         uses: microsoft/setup-msbuild@v2
-        with:
-          msbuild-architecture: ${{ matrix.arch }}
 
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.2.0
 
-      - name: Restore
-        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
+      - name: Restore Packages
+        run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
-      - name: Build
+      - name: Build Solution
         run: msbuild "Scripts/nightly.proj" /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.2.0
 
-      - name: Restore Packages
-        run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
+      - name: Restore
+        run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
-      - name: Build Solution
-        run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" /p:Platform="${{ matrix.arch }}" /p:Configuration="Release"
+      - name: Build (x86/x64 per Matrix)
+        run: dotnet build "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" -c Release /p:Platform="${{ matrix.arch }}"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,13 @@ on:
     branches: ['**']
     types: [opened, synchronize, reopened]
   push:
-    branches: ['**']
+    branches:
+      - master
+      - alpha
+      - canary
+      - gold
+      - V95
+      - V85-LTS
     paths-ignore: ['.git*', '.vscode']
 
 jobs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        arch: [x86, x64]
+        arch: [x64]
 
     steps:
       - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           dotnet-version: 10.0.x
           dotnet-quality: preview
 
-      # global.json dynamisch erzeugen
+      # create global.json dynamically
       - name: Force .NET 10 SDK via global.json
         run: |
           $sdkVersion = (dotnet --list-sdks | Select-String "10.0").ToString().Split(" ")[0]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-﻿name: Build
+name: Build
 
 on:
     pull_request:
@@ -25,6 +25,15 @@ jobs:
               with:
                   ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
 
+            - name: Setup .NET SDKs
+              uses: actions/setup-dotnet@v4
+              with:
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
+                  include-prerelease: true
+
             - name: Setup MSBuild
               uses: microsoft/setup-msbuild@v1
 
@@ -32,8 +41,8 @@ jobs:
               uses: NuGet/setup-nuget@v1.0.6
 
             - name: Restore Packages
-              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
+              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
 
             - name: Build Solution
-              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" /p:platform="Any CPU" /p:configuration="Release"
+              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" /p:platform="Any CPU" /p:configuration="Release"
 # End of workflow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,8 @@ jobs:
               uses: NuGet/setup-nuget@v1.0.6
 
             - name: Restore Packages
-              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
             - name: Build Solution
-              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" /p:platform="Any CPU" /p:configuration="Release"
+              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" /p:platform="Any CPU" /p:configuration="Release"
 # End of workflow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,14 @@ jobs:
       - name: Setup NuGet
         uses: NuGet/setup-nuget@v1.2.0
 
+      - name: Cache NuGet
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
       - name: Restore
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,48 +1,49 @@
 name: Build
 
 on:
-    pull_request:
-        branches:
-            - '**'
-        types:
-            - opened
-            - synchronize
-            - reopened
-    push:
-        branches:
-            - '**'
-        paths-ignore:
-            - '.git*'
-            - '.vscode'
+  pull_request:
+    branches: ['**']
+    types: [opened, synchronize, reopened]
+  push:
+    branches: ['**']
+    paths-ignore: ['.git*', '.vscode']
 
 jobs:
-    build:
-        runs-on: windows-2022
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v2
-              with:
-                  ref: ${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  build:
+    runs-on: windows-2022
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
-            - name: Setup .NET SDKs
-              uses: actions/setup-dotnet@v4
-              with:
-                  dotnet-version: |
-                      8.0.x
-                      9.0.x
-                      10.0.x
-                  include-prerelease: true
+    strategy:
+      matrix:
+        arch: [x86, x64]
 
-            - name: Setup MSBuild
-              uses: microsoft/setup-msbuild@v1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
 
-            - name: Setup NuGet
-              uses: NuGet/setup-nuget@v1.0.6
+      # .NET 9 (GA)
+      - name: Setup .NET 9
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
 
-            - name: Restore Packages
-              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
+      # .NET 10 (Preview)
+      - name: Setup .NET 10 (preview)
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          dotnet-quality: preview
 
-            - name: Build Solution
-              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" /p:platform="Any CPU" /p:configuration="Release"
-# End of workflow
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+        with:
+          msbuild-architecture: ${{ matrix.arch }}
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.2.0
+
+      - name: Restore Packages
+        run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
+
+      - name: Build Solution
+        run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" /p:Platform="${{ matrix.arch }}" /p:Configuration="Release"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,8 +41,8 @@ jobs:
               uses: NuGet/setup-nuget@v1.0.6
 
             - name: Restore Packages
-              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx"
+              run: nuget restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
             - name: Build Solution
-              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.slnx" /p:platform="Any CPU" /p:configuration="Release"
+              run: msbuild.exe "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" /p:platform="Any CPU" /p:configuration="Release"
 # End of workflow

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,4 +48,4 @@ jobs:
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
       - name: Build
-        run: dotnet msbuild "Scripts/nightly.proj" -t:Rebuild -v:m -p:ContinuousIntegrationBuild=true
+        run: msbuild "Scripts/nightly.proj" /t:Rebuild /p:Configuration=Release /p:Platform="Any CPU"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,10 +19,6 @@ jobs:
     runs-on: windows-2022
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
 
-    strategy:
-      matrix:
-        arch: [x64]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -51,5 +47,5 @@ jobs:
       - name: Restore
         run: dotnet restore "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln"
 
-      - name: Build (x86/x64 per Matrix)
-        run: dotnet build "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" -c Release /p:Platform="${{ matrix.arch }}"
+      - name: Build
+        run: dotnet build "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" -c Release


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to restore and build the VS2022 solution on any branch push and repository-owned pull request

## Testing
- `dotnet build "Source/Krypton Components/Krypton Toolkit Suite 2022 - VS2022.sln" -c Debug` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a8d744c6408320a3a49a890590bc34